### PR TITLE
fixes #85

### DIFF
--- a/src/netrics/netson.py
+++ b/src/netrics/netson.py
@@ -444,6 +444,7 @@ class Measurements:
             return
 
         output = {}
+        res = None
         for site in sites:
             tr_cmd = f'traceroute {site}'
 


### PR DESCRIPTION
Initializes `res` at beginning. Failure to do so crashed test.