### PR TITLE
influxdb client code migration and other updates to nm-exp-active-netrics

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ certifi==2020.12.5
 chardet==4.0.0
 idna==2.10
 influxdb==5.3.1
-influxdb-client==1.14.0
+influxdb-client==1.29.1
 msgpack==1.0.2
 python-dateutil==2.8.1
 python-dotenv==0.15.0

--- a/scripts/make_speedtest.sh
+++ b/scripts/make_speedtest.sh
@@ -16,7 +16,8 @@ else
   sudo apt-get install -y gnupg1 apt-transport-https dirmngr
 
   # https://www.speedtest.net/apps/cli
-  curl -s https://install.speedtest.net/app/cli/install.deb.sh | sudo bash
+  curl -s https://packagecloud.io/install/repositories/ookla/speedtest-cli/script.deb.sh | sudo bash
+  # curl -s https://install.speedtest.net/app/cli/install.deb.sh | sudo bash
 
   # Other non-official binaries will conflict with Speedtest CLI
   # Example how to remove using apt-get


### PR DESCRIPTION
This PR addresses the following:
1. It updates the code so that the new influxdb-client python library is used. The existing code was not working when pointed to an InfluxDB v2 instance
2. Points the make_speedtest.sh setup script to an updated URL link provided by Ookla, necessary to download the latest repository for installing  the "speedtest" CLI tool